### PR TITLE
WIP: Ensure that response logging will work

### DIFF
--- a/step-5-dude-r-u-200-ok.md
+++ b/step-5-dude-r-u-200-ok.md
@@ -18,6 +18,7 @@ private int localServerPort;
 
 @Before
 public void setUpAbstractIntegrationTest() {
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     requestSpecification = new RequestSpecBuilder()
             .setPort(localServerPort)
             .addHeader(


### PR DESCRIPTION
I'm not sure why but the use of `.log().ifValidationFails(LogDetail.ALL);` does not seem to work. Nothing gets logged.

This PR 'fixes' the problem by applying a global setting for RestAssured, but I'd like to look into why the existing approach does not seem to work.
