### PR TITLE
Remove reactive rudiments from 8-edge-case.md

### DIFF
--- a/step-8-edge-cases.md
+++ b/step-8-edge-cases.md
@@ -21,16 +21,15 @@ public class RatingsRepositoryTest {
 
     @Test
     public void testEmptyIfNoKey() {
-        assertThat(repository.findAll(talkId).block()).isEmpty();
+        assertThat(repository.findAll(talkId)).isEmpty();
     }
 
     @Test
     public void testLimits() {
-        repository.redisOperations.opsForHash()
-                .put(repository.toKey(talkId), "5", Long.MAX_VALUE + "")
-                .block();
+        repository.redisTemplate.opsForHash()
+                .put(repository.toKey(talkId), "5", Long.MAX_VALUE + "");
 
-        repository.add(talkId, 5).block();
+        repository.add(talkId, 5);
     }
 }
 ```


### PR DESCRIPTION
There was some stuff still in the examples.