### PR TITLE
Exclude junit.jupiter since it 's not used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ dependencies {
 
     compile 'org.postgresql:postgresql'
 
-    testCompile 'org.springframework.boot:spring-boot-starter-test'
+    testCompile ('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.jupiter', module: 'junit-jupiter'
+    }
     testCompile 'io.rest-assured:rest-assured:3.1.0'
     testCompile 'org.testcontainers:postgresql'
     testCompile 'org.testcontainers:kafka'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile 'org.postgresql:postgresql'
 
     testCompile ('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'org.junit.jupiter', module: 'junit-jupiter'
+        exclude group: 'org.junit.jupiter', module: 'junit-jupiter-api'
     }
     testCompile 'io.rest-assured:rest-assured:3.1.0'
     testCompile 'org.testcontainers:postgresql'


### PR DESCRIPTION
Spring Boot 2.2  provides JUnit 5 by default, junit-jupiter and junit-vintage-engine.
JUnit 5’s vintage engine is included by default to support existing JUnit 4-based test classes

Since all examples are based on junit 4 then only junit-vintage-engine is needed.

Does it matter? Not really, but it can be confusing since the @Test annotation is available in both   junit-jupiter and junit-vintage-engine ;-)