### PR TITLE
Add dev container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java-8
+{
+	"name": "Java 8",
+	"image": "mcr.microsoft.com/devcontainers/java:1-8-buster",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "true"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"java.import.gradle.java.home": "/usr/local/sdkman/candidates/java/current",
+				"java.configuration.runtimes": [
+					{
+						"default": true,
+						"name": "JavaSE-1.8",
+						"path": "/usr/local/sdkman/candidates/java/current"
+					}
+				]
+			},
+			"extensions": [
+				"vscjava.vscode-java-pack",
+				"vscjava.vscode-gradle"
+			]
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=140400673&machine=standardLinux32gb&location=WestEurope)
+
 # Introduction
 
 This workshop will explain how to use Testcontainers \( [https://www.testcontainers.org](https://www.testcontainers.org) \) in your Java applications.


### PR DESCRIPTION
This PR adds the [dev container](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers) config, to make using the workshop with GitHub Codespaces easier.

The dev container installs JDK8 and Gradle and also enables the corresponding VSCode Java and Gradle extension as a default. 

Docker is enabled through the `docker-in-docker` feature.