### PR TITLE
Add additional steps for custom modules and chaos engineering

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,4 +11,5 @@
 * [Step 8: Edge cases](step-8-edge-cases.md)
 * [Step 9: Data initialization strategies](step-9-data-init-strategies.md)
 * [Step 10: Migrating from Docker Compose](step-10-migrating-from-docker-compose.md)
-
+* [Step 11: Chaos Engineering](step-11-chaos-engineering.md)
+* [Step 12: Custom Modules](step-12-custom-modules.md)

--- a/step-11-chaos-engineering.md
+++ b/step-11-chaos-engineering.md
@@ -1,0 +1,22 @@
+# Step 11: Using Testcontainers for Chaos Engineering
+
+So far we have tested our system under very expected conditions.
+But in reality, we know that things can go wrong.
+The network can be slow, the database can be unavailable, and so on.
+
+In this step, we will use Testcontainers to simulate such conditions and see how our system behaves.
+
+For this, we will use the [Toxiproxy](https://www.testcontainers.org/modules/toxiproxy/) module.
+
+Check out the documentation and write a test that checks the following test scenario:
+1. Initially, PostgreSQL is available, and we can record a rating.
+2. We then simulate a network outage between our application and PostgreSQL using Toxiproxy, and we expect the endpoint to return an error.
+3. We then simulate a network recovery, and we expect the endpoint to return a success.
+
+## Hint
+
+You need to add the Toxiproxy module to your project's dependencies.
+You also need a Toxiproxy client, such as:
+```groovy
+testImplementation("eu.rekawek.toxiproxy:toxiproxy-java:2.1.0")
+```

--- a/step-12-custom-modules.md
+++ b/step-12-custom-modules.md
@@ -1,0 +1,26 @@
+# Step 12: Custom Modules
+
+Testcontainers provides a range of extension points to write your own modules 
+and you are not limited to the modules that are provided out of the box.
+Such a container module can be used to encapsulate the logic of starting a container for a specific service,
+and configuring it accordingly.
+
+Writing a custom container module is normally done by creating a new class that extends `GenericContainer`.
+
+And although using the `GenericContainer` for Redis is perfectly fine, we want to get a feeling for writing a custom module,
+by writing a `RedisContainer` that extends `GenericContainer` and has the corresponding configuration applied.
+
+What about a helper method, returning a Redis URI?
+```
+redis :// [[username :] password@] host [:port][/database]
+          [?[timeout=timeout[d|h|m|s|ms|us|ns]]
+```
+
+We also want to make sure, a user can't use the container accidentally with a wrong Docker image.
+For this, you can make use of the `dockerImage.assertCompatibleWith(compatibleImageName)` method.
+
+## Bonus
+
+A container module can also be an abstraction for multiple containers.
+Write a `ToxicPostgreSQLContainer` that starts a PostgreSQL container and a Toxiproxy container, 
+providing more convenient methods for cutting the connection or introducing other failures.


### PR DESCRIPTION
Step 11 represents a Chaos Engineering exercise.
Step 12 handles Custom Modules.

Both steps are very open regarding the instructions. Since they are intended for very long workshops, they serve as an very open exercise, requiring a higher degree of knowledge transfer from the former exercises.